### PR TITLE
Interactive CLI summary management

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ ollama pull llama2
 python examples/run_example.py --path /path/to/folder
 ```
 
+After showing the generated summary the CLI now provides interactive options:
+
+* **a**ccept - use the summary and generate metadata
+* **r**egenerate - run summarization again
+* **e**dit - edit the summary text manually
+* **c**ancel - exit without generating metadata
+
 ## Testing
 ```
 pytest

--- a/folder_organizer/cli.py
+++ b/folder_organizer/cli.py
@@ -18,12 +18,30 @@ def main() -> None:
 
     docs = load_documents(args.path)
     summary = summarize_documents(docs)
-    print("Summary:\n", summary)
 
-    confirm = prompt("Accept summary? (y/n) ")
-    if confirm.lower().startswith("y"):
-        metadata = generate_metadata(args.path, summary, list_files(args.path))
-        print("Metadata:\n", metadata)
+    while True:
+        print("Summary:\n", summary)
+        action = prompt(
+            "Options: [a]ccept/[r]egenerate/[e]dit/[c]ancel: "
+        ).strip().lower()
+
+        if action.startswith("a"):
+            metadata = generate_metadata(
+                args.path, summary, list_files(args.path)
+            )
+            print("Metadata:\n", metadata)
+            break
+        if action.startswith("r"):
+            summary = summarize_documents(docs)
+            continue
+        if action.startswith("e"):
+            summary = prompt("Edit summary:", default=summary)
+            continue
+        if action.startswith("c"):
+            break
+        else:
+            print("Invalid option, please try again.")
+            continue
 
 
 if __name__ == "__main__":

--- a/folder_organizer/metadata.py
+++ b/folder_organizer/metadata.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+import sys
+from folder_organizer import cli
+
+
+def test_cli_accept_after_regenerate(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["prog", "--path", str(tmp_path)])
+    monkeypatch.setattr(cli, "load_documents", lambda path: ["doc"])
+    summaries = iter(["s1", "s2"])
+    monkeypatch.setattr(cli, "summarize_documents", lambda docs: next(summaries))
+    prompts = iter(["r", "a"])
+    monkeypatch.setattr(cli, "prompt", lambda msg, default=None: next(prompts))
+    captured = {}
+
+    def fake_generate(path, summary, files):
+        captured["summary"] = summary
+        return {}
+
+    monkeypatch.setattr(cli, "generate_metadata", fake_generate)
+    monkeypatch.setattr(cli, "list_files", lambda path: [])
+
+    cli.main()
+    assert captured["summary"] == "s2"
+
+
+def test_cli_edit_cancel(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["prog", "--path", str(tmp_path)])
+    monkeypatch.setattr(cli, "load_documents", lambda path: ["doc"])
+    monkeypatch.setattr(cli, "summarize_documents", lambda docs: "orig")
+    prompts = iter(["e", "edited", "c"])
+    monkeypatch.setattr(cli, "prompt", lambda msg, default=None: next(prompts))
+    calls = []
+
+    def fake_generate(path, summary, files):
+        calls.append(True)
+        return {}
+
+    monkeypatch.setattr(cli, "generate_metadata", fake_generate)
+    monkeypatch.setattr(cli, "list_files", lambda path: [])
+
+    cli.main()
+    assert not calls

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,4 +5,6 @@ def test_generate_metadata(tmp_path):
     meta = generate_metadata("/tmp", "summary", ["a.txt"])
     assert meta["path"] == "/tmp"
     assert meta["summary"] == "summary"
+    # tags are required by the schema
+    assert "tags" in meta
     assert "created_at" in meta


### PR DESCRIPTION
## Summary
- add interactive loop to `folder_organizer.cli.main`
- import `timezone` for metadata timestamps
- document interactive options in README
- add CLI tests for accept/regenerate/edit/cancel behaviour
- check for tags in metadata tests
- handle invalid options in CLI loop

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859e93bf990832db7f7b91f1860d1fa