### PR TITLE
Interactive CLI summary management

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ ollama pull llama2
 python examples/run_example.py --path /path/to/folder
 ```
 
+After showing the generated summary the CLI now provides interactive options:
+
+* **a**ccept - use the summary and generate metadata
+* **r**egenerate - run summarization again
+* **e**dit - edit the summary text manually
+* **c**ancel - exit without generating metadata
+
+Logging is enabled at the INFO level to help troubleshoot issues. Set the
+`LOGLEVEL` environment variable to `DEBUG` for more verbose output.
+
 ## Testing
 ```
 pytest

--- a/folder_organizer/cli.py
+++ b/folder_organizer/cli.py
@@ -3,27 +3,60 @@ from __future__ import annotations
 
 import argparse
 from prompt_toolkit import prompt
+import logging
+import os
 
 from .loader import load_documents
 from .summarizer import summarize_documents
 from .metadata import generate_metadata
 from .utils import list_files
 
+logger = logging.getLogger(__name__)
+
 
 def main() -> None:
     """Entry point for the CLI."""
+    level_name = os.getenv("LOGLEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(level=level)
     parser = argparse.ArgumentParser(description="Summarize a folder")
     parser.add_argument("--path", required=True, help="Path to folder or file")
     args = parser.parse_args()
 
+    logger.info("Loading documents from %s", args.path)
     docs = load_documents(args.path)
+    logger.info("Summarizing %d documents", len(docs))
     summary = summarize_documents(docs)
-    print("Summary:\n", summary)
 
-    confirm = prompt("Accept summary? (y/n) ")
-    if confirm.lower().startswith("y"):
-        metadata = generate_metadata(args.path, summary, list_files(args.path))
-        print("Metadata:\n", metadata)
+    while True:
+        print("Summary:\n", summary)
+        action = prompt(
+            "Options: [a]ccept/[r]egenerate/[e]dit/[c]ancel: "
+        ).strip().lower()
+        logger.debug("User selected action: %s", action)
+
+        if action.startswith("a"):
+            logger.info("User accepted summary; generating metadata")
+            metadata = generate_metadata(
+                args.path, summary, list_files(args.path)
+            )
+            print("Metadata:\n", metadata)
+            break
+        if action.startswith("r"):
+            logger.info("Regenerating summary")
+            summary = summarize_documents(docs)
+            continue
+        if action.startswith("e"):
+            logger.info("Editing summary")
+            summary = prompt("Edit summary:", default=summary)
+            continue
+        if action.startswith("c"):
+            logger.info("User cancelled")
+            break
+        else:
+            logger.warning("Invalid option: %s", action)
+            print("Invalid option, please try again.")
+            continue
 
 
 if __name__ == "__main__":

--- a/folder_organizer/loader.py
+++ b/folder_organizer/loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List
 from zipfile import is_zipfile
+import logging
 
 from langchain_community.document_loaders import (
     PyPDFLoader,
@@ -12,6 +13,8 @@ from langchain_community.document_loaders import (
     UnstructuredMarkdownLoader,
 )
 from langchain.docstore.document import Document
+
+logger = logging.getLogger(__name__)
 
 
 def load_documents(path: str) -> List[Document]:
@@ -27,6 +30,7 @@ def load_documents(path: str) -> List[Document]:
     List[Document]
         Loaded documents.
     """
+    logger.info("Loading documents from path %s", path)
     p = Path(path)
     docs: List[Document] = []
 
@@ -35,15 +39,17 @@ def load_documents(path: str) -> List[Document]:
             docs.extend(_load_file(file))
     else:
         docs.extend(_load_file(p))
+    logger.debug("Loaded %d document(s)", len(docs))
     return docs
 
 
 def _load_file(file: Path) -> List[Document]:
     """Load a single file."""
     if not file.exists():
+        logger.warning("File does not exist: %s", file)
         return []
     if is_zipfile(file):
-        # Skip archives
+        logger.info("Skipping archive %s", file)
         return []
     suffix = file.suffix.lower()
     if suffix == ".pdf":
@@ -56,10 +62,13 @@ def _load_file(file: Path) -> List[Document]:
         loader = TextLoader(str(file), autodetect_encoding=True)
     else:
         # unsupported file type
+        logger.info("Unsupported file type: %s", file)
         return []
 
     try:
+        logger.debug("Loading file %s", file)
         return loader.load()
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to load %s: %s", file, exc)
         # skip files that cannot be read (e.g. unknown encoding)
         return []

--- a/folder_organizer/metadata.py
+++ b/folder_organizer/metadata.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
+import logging
 
 from jsonschema import Draft7Validator
 
@@ -15,9 +16,12 @@ with SCHEMA_PATH.open("r", encoding="utf-8") as f:
 
 VALIDATOR = Draft7Validator(METADATA_SCHEMA)
 
+logger = logging.getLogger(__name__)
+
 
 def generate_metadata(path: str, summary: str, source_files: List[str]) -> Dict[str, Any]:
     """Generate and validate metadata for a folder or file."""
+    logger.info("Generating metadata for %s", path)
     metadata = {
         "path": path,
         "summary": summary,
@@ -26,4 +30,5 @@ def generate_metadata(path: str, summary: str, source_files: List[str]) -> Dict[
         "source_files": source_files,
     }
     VALIDATOR.validate(metadata)
+    logger.debug("Metadata validated successfully")
     return metadata

--- a/folder_organizer/utils.py
+++ b/folder_organizer/utils.py
@@ -3,13 +3,19 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List
+import logging
 
 
 def list_files(path: str) -> List[str]:
     """Return list of file paths under a directory."""
+    logger = logging.getLogger(__name__)
     p = Path(path)
     if p.is_dir():
-        return [str(f) for f in p.rglob("*") if f.is_file()]
+        files = [str(f) for f in p.rglob("*") if f.is_file()]
+        logger.debug("Listing %d files in %s", len(files), path)
+        return files
     if p.exists():
+        logger.debug("Listing single file %s", path)
         return [str(p)]
+    logger.warning("Path does not exist: %s", path)
     return []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+import sys
+from folder_organizer import cli
+
+
+def test_cli_accept_after_regenerate(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["prog", "--path", str(tmp_path)])
+    monkeypatch.setattr(cli, "load_documents", lambda path: ["doc"])
+    summaries = iter(["s1", "s2"])
+    monkeypatch.setattr(cli, "summarize_documents", lambda docs: next(summaries))
+    prompts = iter(["r", "a"])
+    monkeypatch.setattr(cli, "prompt", lambda msg, default=None: next(prompts))
+    captured = {}
+
+    def fake_generate(path, summary, files):
+        captured["summary"] = summary
+        return {}
+
+    monkeypatch.setattr(cli, "generate_metadata", fake_generate)
+    monkeypatch.setattr(cli, "list_files", lambda path: [])
+
+    cli.main()
+    assert captured["summary"] == "s2"
+
+
+def test_cli_edit_cancel(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["prog", "--path", str(tmp_path)])
+    monkeypatch.setattr(cli, "load_documents", lambda path: ["doc"])
+    monkeypatch.setattr(cli, "summarize_documents", lambda docs: "orig")
+    prompts = iter(["e", "edited", "c"])
+    monkeypatch.setattr(cli, "prompt", lambda msg, default=None: next(prompts))
+    calls = []
+
+    def fake_generate(path, summary, files):
+        calls.append(True)
+        return {}
+
+    monkeypatch.setattr(cli, "generate_metadata", fake_generate)
+    monkeypatch.setattr(cli, "list_files", lambda path: [])
+
+    cli.main()
+    assert not calls

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,4 +5,6 @@ def test_generate_metadata(tmp_path):
     meta = generate_metadata("/tmp", "summary", ["a.txt"])
     assert meta["path"] == "/tmp"
     assert meta["summary"] == "summary"
+    # tags are required by the schema
+    assert "tags" in meta
     assert "created_at" in meta


### PR DESCRIPTION
## Summary
- add interactive loop to `folder_organizer.cli.main`
- import `timezone` for metadata timestamps
- document interactive options in README
- add CLI tests for accept/regenerate/edit/cancel behaviour
- check for tags in metadata tests
- handle invalid options in CLI loop
- **add detailed logging across modules for troubleshooting**

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859e93bf990832db7f7b91f1860d1fa